### PR TITLE
Feature: Prevent overlapping bookings

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -16,14 +16,21 @@ class BookingsController < ApplicationController
 
   def create
     @listing = Listing.find(params[:listing_id])
-    @booking = @listing.bookings.new(booking_params)
+    @booking = CreateBookingService.(
+      @listing, current_user.id, 
+      booking_params[:start_date], 
+      booking_params[:end_date], 
+      booking_params[:number_of_guests]
+    )
 
-    if @booking.save
+    if @booking.persisted?
       redirect_to booking_path(@booking), notice: "Booking was successfully created."
     else
-      redirect_to booking_path(@booking), notice: "Failed to create booking."
       render :new, status: :unprocessable_entity
     end
+
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to listing_path(@listing), alert: e.message
   end
 
   private

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
   static targets = ["dateInput", "startDate", "endDate"]
 
   connect() {
-    const availableDates = JSON.parse(this.dateInputTarget.dataset.availableDates)
+    const unavailableDates = JSON.parse(this.dateInputTarget.dataset.unavailableDates)
 
     flatpickr(
       this.dateInputTarget,
@@ -17,17 +17,7 @@ export default class extends Controller {
             this.endDateTarget.value = selectedDates[1].toISOString()
           }
         },
-        enable: availableDates.flatMap(range => {
-          const dates = []
-          let currentDate = new Date(range.from)
-          const endDate = new Date(range.to)
-          
-          while (currentDate <= endDate) {
-            dates.push(new Date(currentDate))
-            currentDate.setDate(currentDate.getDate() + 1)
-          }
-          return dates
-        })
+        disable: unavailableDates
       }
     )
   }

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -9,4 +9,10 @@ class Listing < ApplicationRecord
 
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?
+
+  def unavailable_dates
+    bookings.pluck(:start_date, :end_date).map do |start_date, end_date|
+      (start_date.to_date..end_date.to_date).map(&:to_s)
+    end.flatten
+  end
 end

--- a/app/services/create_booking_service.rb
+++ b/app/services/create_booking_service.rb
@@ -1,0 +1,33 @@
+class CreateBookingService
+    def self.call(listing, user_id, start_date, end_date, number_of_guests)
+        # Use advisory lock to prevent concurrent bookings for same listing/dates
+        lock_key = "booking_lock_#{listing.id}"
+        
+        ApplicationRecord.transaction do
+            # Obtain advisory lock
+            ApplicationRecord.connection.execute("SELECT pg_advisory_xact_lock(#{lock_key.hash})")
+            
+            # Check for overlapping bookings
+            overlapping_bookings = listing.bookings.where(
+                "start_date <= ? AND end_date >= ?", 
+                end_date, start_date
+            )
+            
+            if overlapping_bookings.exists?
+                raise ActiveRecord::RecordInvalid
+            end
+            
+            # Create the booking if no overlaps
+            booking = listing.bookings.new(
+                user_id: user_id,
+                start_date: start_date,
+                end_date: end_date,
+                number_of_guests: number_of_guests
+            )
+            
+            booking.save
+            
+            booking
+        end
+    end
+end

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -48,7 +48,7 @@
         <%= simple_form_for Booking.new, url: new_listing_booking_path(@listing), method: :get, html: { data: { controller: "datepicker" }, class: "mt-3" } do |f| %>
           <input type="text"
                  data-datepicker-target="dateInput"
-                 data-available-dates="<%= @listing.availabilities.map { |a| { from: a.start_date, to: a.end_date } }.to_json %>"
+                 data-unavailable-dates="<%= @listing.unavailable_dates.to_json %>"
                  data-disabled-dates="true"
                  placeholder="Pick date"
                  style="color: #6c757d;">


### PR DESCRIPTION
1. Prevent user from selecting dates that have already been booked on listings#show
2. Do a confirmation check that no user has booked the listing for selected date on bookings#create
3. Use an advisory lock to prevent booking race conditions

For more on advisory locks, see:
https://firehydrant.com/blog/using-advisory-locks-to-avoid-race-conditions-in-rails/

Related readings on database locks:
https://medium.com/@radadiyahardik355/understanding-locking-in-rails-optimistic-vs-pessimistic-strategies-a48530e2245e

And I guess database transactions:
https://www.honeybadger.io/blog/database-transactions-rails-activerecord/